### PR TITLE
[translate] allow users to specify sources directories

### DIFF
--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy
@@ -99,6 +99,20 @@ class J2objcConfig {
     String destLibDir = null
 
     /**
+     * Java sources directories
+     * <p />
+     * Defaults to the java plugin main source sets
+     */
+    Set<String> srcMainDirs = new HashSet<>()
+
+    /**
+     * Java test sources directories
+     * <p />
+     * Defaults to the java plugin test source sets
+     */
+    Set<String> srcTestDirs = new HashSet<>()
+
+    /**
      * Where to assemble generated main source and resources files.
      * <p/>
      * Defaults to $buildDir/j2objcOutputs/src/main/objc


### PR DESCRIPTION
Hello there, I saw that you continued a little the work on this project.
Also you had published your work to the gradle plugin repo, simply awesome :sunglasses: 

I added a config property to let users change the sources that will be translated, bypassing the java sources hardconding.

If you don't change the configuration properties the behavior it's exactly the same as before ( same method calls ), so it is perfectly backward compatible.

I hope this helps you in some way :blush: 
